### PR TITLE
Fix conversion issue on maxRap after changing backing data to metric

### DIFF
--- a/Canyoneer/Canyoneer.xcodeproj/project.pbxproj
+++ b/Canyoneer/Canyoneer.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		40E8E6DD2B801AD8002EB480 /* UpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E8E6DC2B801AD8002EB480 /* UpdateManager.swift */; };
 		40E8E6E22B802D5D002EB480 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E8E6E12B802D5D002EB480 /* ProfileView.swift */; };
 		40E8E6E42B802D76002EB480 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E8E6E32B802D76002EB480 /* ProfileViewModel.swift */; };
+		40F17C712BAF284B00BEBFF9 /* FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F17C702BAF284B00BEBFF9 /* FilterState.swift */; };
+		40F17C732BAF286C00BEBFF9 /* FilterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F17C722BAF286B00BEBFF9 /* FilterStateTests.swift */; };
 		40FDB37E2791CF5D0065FF47 /* MapboxMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FDB37D2791CF5D0065FF47 /* MapboxMap.swift */; };
 		40FDB3832791D0E30065FF47 /* TopoLineType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FDB3822791D0E30065FF47 /* TopoLineType.swift */; };
 		40FDB3862791FAA00065FF47 /* CoreGPX in Frameworks */ = {isa = PBXBuildFile; productRef = 40FDB3852791FAA00065FF47 /* CoreGPX */; };
@@ -330,6 +332,8 @@
 		40E8E6DC2B801AD8002EB480 /* UpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateManager.swift; sourceTree = "<group>"; };
 		40E8E6E12B802D5D002EB480 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		40E8E6E32B802D76002EB480 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
+		40F17C702BAF284B00BEBFF9 /* FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterState.swift; sourceTree = "<group>"; };
+		40F17C722BAF286B00BEBFF9 /* FilterStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterStateTests.swift; sourceTree = "<group>"; };
 		40FDB37D2791CF5D0065FF47 /* MapboxMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxMap.swift; sourceTree = "<group>"; };
 		40FDB3822791D0E30065FF47 /* TopoLineType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopoLineType.swift; sourceTree = "<group>"; };
 		40FDB3872791FCCB0065FF47 /* GPXService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXService.swift; sourceTree = "<group>"; };
@@ -778,6 +782,8 @@
 		40E4433D2788F1C800FE245D /* Filters */ = {
 			isa = PBXGroup;
 			children = (
+				40F17C702BAF284B00BEBFF9 /* FilterState.swift */,
+				40F17C722BAF286B00BEBFF9 /* FilterStateTests.swift */,
 				4005DFBF278F60C500EB1640 /* CanyonFilterViewModel.swift */,
 				4005DFC4278F6F0300EB1640 /* CanyonFilterViewModelTests+update.swift */,
 				4005DFC6278F733400EB1640 /* CanyonFilterViewModelTests+filter.swift */,
@@ -949,6 +955,7 @@
 				40DF5FA72B1BF1A9007A076F /* Canyon+detailString.swift in Sources */,
 				40FDB37E2791CF5D0065FF47 /* MapboxMap.swift in Sources */,
 				40FDB3882791FCCB0065FF47 /* GPXService.swift in Sources */,
+				40F17C712BAF284B00BEBFF9 /* FilterState.swift in Sources */,
 				40E442F82787770200FE245D /* ContainedButton.swift in Sources */,
 				401248B22B26B28C00E40553 /* CanyonPreview.swift in Sources */,
 				40DF5F9E2B1BB460007A076F /* MainTabView.swift in Sources */,
@@ -1079,6 +1086,7 @@
 				4089A1332B0AC9CF00886179 /* CoordinateTests.swift in Sources */,
 				40A63B4A2B3338A500996567 /* FavoriteServiceTests.swift in Sources */,
 				4032AECB278F3FD8002EEA4E /* MockCanyonAPIService.swift in Sources */,
+				40F17C732BAF286C00BEBFF9 /* FilterStateTests.swift in Sources */,
 				40A09BF62B8275BB00254501 /* CanyonDataManagerTests.swift in Sources */,
 				40A09C1A2B82D90000254501 /* CanyonFilterViewModelTests+update.swift in Sources */,
 				40A09C172B82D90000254501 /* WeatherDataPointTests+Strings.swift in Sources */,

--- a/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModel.swift
@@ -7,54 +7,6 @@
 
 import Foundation
 
-struct FilterState {
-    let maxRap: Bounds // In FT
-    let numRaps: Bounds
-    let stars: Set<Int>
-    let technicality: Set<TechnicalGrade>
-    let water: Set<WaterGrade>
-    let time: Set<TimeGrade>
-    let shuttleRequired: Bool?
-    let seasons: Set<Month>
-    
-    public static let `default` = FilterState(
-        maxRap: Bounds(min: 0, max: Int(FilterState.maxRapLimit.converted(to: .meters).value.rounded())),
-        numRaps: Bounds(min: 0, max: FilterState.numRapsLimit),
-        stars: [1,2,3,4,5],
-        technicality: Set(TechnicalGrade.allCases),
-        water: Set(WaterGrade.allCases),
-        time: Set(TimeGrade.allCases),
-        shuttleRequired: nil,
-        seasons: Set(Month.allCases)
-    )
-    
-    private static let maxRapLimit = Measurement(value: 600, unit: UnitLength.feet)
-    public static let maxRapIncrement = Measurement(value: 10, unit: UnitLength.feet)
-    private static let numRapsLimit: Int = 50
-    public static let numRapsIncrement: Int = 1
-    
-    // Default params just used for testing
-    init(
-        maxRap: Bounds = FilterState.default.maxRap,
-        numRaps: Bounds = FilterState.default.numRaps,
-        stars: Set<Int> = FilterState.default.stars,
-        technicality: Set<TechnicalGrade> = FilterState.default.technicality,
-        water: Set<WaterGrade> = FilterState.default.water,
-        time: Set<TimeGrade> = FilterState.default.time,
-        shuttleRequired: Bool? = FilterState.default.shuttleRequired,
-        seasons: Set<Month> = FilterState.default.seasons
-    ) {
-        self.maxRap = maxRap
-        self.numRaps = numRaps
-        self.stars = stars
-        self.technicality = technicality
-        self.water = water
-        self.time = time
-        self.shuttleRequired = shuttleRequired
-        self.seasons = seasons
-    }
-}
-
 @MainActor
 class CanyonFilterViewModel: ObservableObject {
     // Compiled

--- a/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModelTests+update.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModelTests+update.swift
@@ -20,7 +20,7 @@ class CanyonFilterViewModelUpdateTests: XCTestCase {
         XCTAssertEqual(currentState.numRaps.min, 0)
         XCTAssertEqual(currentState.numRaps.max, 50)
         XCTAssertEqual(currentState.maxRap.min, 0)
-        XCTAssertEqual(Double(currentState.maxRap.max), Measurement(value: 600, unit: UnitLength.feet).converted(to: .meters).value.rounded())
+        XCTAssertEqual(Double(currentState.maxRap.max), 600)
         XCTAssertEqual(currentState.stars, [1,2,3,4,5])
         XCTAssertEqual(currentState.technicality, Set(TechnicalGrade.allCases))
         XCTAssertEqual(currentState.water, Set(WaterGrade.allCases))

--- a/Canyoneer/Canyoneer/View/Shared/Filters/FilterState.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/FilterState.swift
@@ -1,0 +1,52 @@
+//  Created by Brice Pollock for Canyoneer on 3/23/24
+
+import Foundation
+
+struct FilterState {
+    /// Maximum rappel lengths, in feet
+    let maxRap: Bounds
+    let numRaps: Bounds
+    let stars: Set<Int>
+    let technicality: Set<TechnicalGrade>
+    let water: Set<WaterGrade>
+    let time: Set<TimeGrade>
+    let shuttleRequired: Bool?
+    let seasons: Set<Month>
+    
+    public static let `default` = FilterState(
+        maxRap: Bounds(min: 0, max: Int(FilterState.maxRapLimit.converted(to: .feet).value.rounded())),
+        numRaps: Bounds(min: 0, max: FilterState.numRapsLimit),
+        stars: [1,2,3,4,5],
+        technicality: Set(TechnicalGrade.allCases),
+        water: Set(WaterGrade.allCases),
+        time: Set(TimeGrade.allCases),
+        shuttleRequired: nil,
+        seasons: Set(Month.allCases)
+    )
+    
+    private static let maxRapLimit = Measurement(value: 600, unit: UnitLength.feet)
+    public static let maxRapIncrement = Measurement(value: 10, unit: UnitLength.feet)
+    private static let numRapsLimit: Int = 50
+    public static let numRapsIncrement: Int = 1
+    
+    // Default params just used for testing
+    init(
+        maxRap: Bounds = FilterState.default.maxRap,
+        numRaps: Bounds = FilterState.default.numRaps,
+        stars: Set<Int> = FilterState.default.stars,
+        technicality: Set<TechnicalGrade> = FilterState.default.technicality,
+        water: Set<WaterGrade> = FilterState.default.water,
+        time: Set<TimeGrade> = FilterState.default.time,
+        shuttleRequired: Bool? = FilterState.default.shuttleRequired,
+        seasons: Set<Month> = FilterState.default.seasons
+    ) {
+        self.maxRap = maxRap
+        self.numRaps = numRaps
+        self.stars = stars
+        self.technicality = technicality
+        self.water = water
+        self.time = time
+        self.shuttleRequired = shuttleRequired
+        self.seasons = seasons
+    }
+}

--- a/Canyoneer/Canyoneer/View/Shared/Filters/FilterStateTests.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/FilterStateTests.swift
@@ -1,0 +1,27 @@
+//  Created by Brice Pollock for Canyoneer on 3/23/24
+
+import Foundation
+import XCTest
+@testable import Canyoneer
+
+@MainActor
+class FilterStateTests: XCTestCase {
+    func testDefault() {
+        let state = FilterState.default
+        XCTAssertEqual(state.maxRap.min, 0)
+        XCTAssertEqual(state.maxRap.max, 600)
+        
+        XCTAssertEqual(state.numRaps.min, 0)
+        XCTAssertEqual(state.numRaps.max, 50)
+        
+        XCTAssertEqual(state.stars.count, 5)
+        
+        XCTAssertEqual(state.technicality.count, 4)
+        XCTAssertEqual(state.water.count, 7)
+        XCTAssertEqual(state.time.count, 6)
+        XCTAssertNil(state.shuttleRequired)
+        XCTAssertEqual(state.seasons.count, 12)
+
+    }
+}
+


### PR DESCRIPTION
### Description
There was an mis-conversion when changing backing data units to metric. We converted 600ft into meters and thus showed 183 ft as the maximum default.

### Test Plan
* Updated tests to ensure no future regression
* Tested defaults now correct in app
