### PR TITLE
[ISSUE-37] Add go-to on map for canyons found in favorites and add coordinate information / copy

### DIFF
--- a/Canyoneer/Canyoneer.xcodeproj/project.pbxproj
+++ b/Canyoneer/Canyoneer.xcodeproj/project.pbxproj
@@ -179,6 +179,14 @@
 		40F8C8032D1C924800C2948B /* CLLocationCoordinate2D+isClose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C8022D1C924800C2948B /* CLLocationCoordinate2D+isClose.swift */; };
 		40F8C80B2D1C96E800C2948B /* CanyoneerTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C8092D1C96E800C2948B /* CanyoneerTips.swift */; };
 		40F8C80D2D1C9D2100C2948B /* SingleCanyonMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C80C2D1C9D2100C2948B /* SingleCanyonMapView.swift */; };
+		40F8C80F2D1CBF9300C2948B /* Double+digits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C80E2D1CBF9300C2948B /* Double+digits.swift */; };
+		40F8C8122D1CC08E00C2948B /* DoubleDigitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C8102D1CC07A00C2948B /* DoubleDigitsTests.swift */; };
+		40F8C8152D1CC1C500C2948B /* PointIsCloseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C8132D1CC1C100C2948B /* PointIsCloseTests.swift */; };
+		40F8C8182D1CC29300C2948B /* CLLocationCoordinate2DIsCloseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C8162D1CC28600C2948B /* CLLocationCoordinate2DIsCloseTests.swift */; };
+		40F8C81A2D1CC74600C2948B /* AppTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C8192D1CC74600C2948B /* AppTab.swift */; };
+		40F8C81C2D1CC86600C2948B /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C81B2D1CC86600C2948B /* MainTabViewModel.swift */; };
+		40F8C81E2D1CCE8C00C2948B /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C81D2D1CCE8C00C2948B /* ToastView.swift */; };
+		40F8C8202D1CCF2700C2948B /* ToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F8C81F2D1CCF2700C2948B /* ToastMessage.swift */; };
 		40FDB37E2791CF5D0065FF47 /* MapboxMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FDB37D2791CF5D0065FF47 /* MapboxMapViewModel.swift */; };
 		40FDB3832791D0E30065FF47 /* TopoLineType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FDB3822791D0E30065FF47 /* TopoLineType.swift */; };
 		40FDB3862791FAA00065FF47 /* CoreGPX in Frameworks */ = {isa = PBXBuildFile; productRef = 40FDB3852791FAA00065FF47 /* CoreGPX */; };
@@ -374,6 +382,14 @@
 		40F8C8022D1C924800C2948B /* CLLocationCoordinate2D+isClose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+isClose.swift"; sourceTree = "<group>"; };
 		40F8C8092D1C96E800C2948B /* CanyoneerTips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanyoneerTips.swift; sourceTree = "<group>"; };
 		40F8C80C2D1C9D2100C2948B /* SingleCanyonMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleCanyonMapView.swift; sourceTree = "<group>"; };
+		40F8C80E2D1CBF9300C2948B /* Double+digits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+digits.swift"; sourceTree = "<group>"; };
+		40F8C8102D1CC07A00C2948B /* DoubleDigitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleDigitsTests.swift; sourceTree = "<group>"; };
+		40F8C8132D1CC1C100C2948B /* PointIsCloseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointIsCloseTests.swift; sourceTree = "<group>"; };
+		40F8C8162D1CC28600C2948B /* CLLocationCoordinate2DIsCloseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationCoordinate2DIsCloseTests.swift; sourceTree = "<group>"; };
+		40F8C8192D1CC74600C2948B /* AppTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTab.swift; sourceTree = "<group>"; };
+		40F8C81B2D1CC86600C2948B /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
+		40F8C81D2D1CCE8C00C2948B /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		40F8C81F2D1CCF2700C2948B /* ToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessage.swift; sourceTree = "<group>"; };
 		40FDB37D2791CF5D0065FF47 /* MapboxMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxMapViewModel.swift; sourceTree = "<group>"; };
 		40FDB3822791D0E30065FF47 /* TopoLineType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopoLineType.swift; sourceTree = "<group>"; };
 		40FDB3872791FCCB0065FF47 /* GPXService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXService.swift; sourceTree = "<group>"; };
@@ -621,6 +637,8 @@
 				40A63B472B33265100996567 /* MainView.swift */,
 				40DF5F9B2B1BB3F0007A076F /* MainViewModel.swift */,
 				40DF5F9D2B1BB460007A076F /* MainTabView.swift */,
+				40F8C81B2D1CC86600C2948B /* MainTabViewModel.swift */,
+				40F8C8192D1CC74600C2948B /* AppTab.swift */,
 				4068C3522B14CE6B0033707F /* Foundation */,
 				40E442C62787601300FE245D /* AppDataKit */,
 				40E442BE27875FB800FE245D /* DesignSystem */,
@@ -668,6 +686,7 @@
 		40E442BE27875FB800FE245D /* DesignSystem */ = {
 			isa = PBXGroup;
 			children = (
+				40F8C8232D1CD16700C2948B /* Toast */,
 				4068C3572B17930F0033707F /* ViewModifiers */,
 				40E442C9278760CB00FE245D /* Components */,
 				40E442D22787610600FE245D /* Foundation */,
@@ -732,7 +751,9 @@
 				40DF5FA62B1BF1A9007A076F /* Canyon+detailString.swift */,
 				40F8C7FE2D1C800300C2948B /* View+border.swift */,
 				40F8C8002D1C921800C2948B /* Point+isClose.swift */,
+				40F8C8132D1CC1C100C2948B /* PointIsCloseTests.swift */,
 				40F8C8022D1C924800C2948B /* CLLocationCoordinate2D+isClose.swift */,
+				40F8C8162D1CC28600C2948B /* CLLocationCoordinate2DIsCloseTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -751,9 +772,9 @@
 			children = (
 				40DF5F9F2B1BB75F007A076F /* Weather */,
 				4068C3552B16F9700033707F /* WebView.swift */,
+				40E4430C2787842800FE245D /* CanyonDetailView.swift */,
 				4068C36E2B18D7B50033707F /* CanyonDetailViewModel.swift */,
 				4032AECC278F41D0002EEA4E /* CanyonDetailViewModelTests.swift */,
-				40E4430C2787842800FE245D /* CanyonDetailView.swift */,
 				40E4430627877F9500FE245D /* CanyonView.swift */,
 				4032AEBE278F324D002EEA4E /* CanyonViewModel.swift */,
 				40DF5FA82B1BFFFB007A076F /* CanyonViewModel+share.swift */,
@@ -816,6 +837,8 @@
 				40FDB3892791FCDE0065FF47 /* Data+toFile.swift */,
 				405E679327973BBE00BA41D9 /* DispatchTime+duration.swift */,
 				40FDB38B2791FCFD0065FF47 /* FileAccess.swift */,
+				40F8C80E2D1CBF9300C2948B /* Double+digits.swift */,
+				40F8C8102D1CC07A00C2948B /* DoubleDigitsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -853,6 +876,15 @@
 				40F8C8092D1C96E800C2948B /* CanyoneerTips.swift */,
 			);
 			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		40F8C8232D1CD16700C2948B /* Toast */ = {
+			isa = PBXGroup;
+			children = (
+				40F8C81F2D1CCF2700C2948B /* ToastMessage.swift */,
+				40F8C81D2D1CCE8C00C2948B /* ToastView.swift */,
+			);
+			path = Toast;
 			sourceTree = "<group>";
 		};
 		40FDB3762791CF170065FF47 /* MapBox */ = {
@@ -1040,6 +1072,7 @@
 				407FB7632790CD2B008B65BE /* NOAASerializer.swift in Sources */,
 				40DF5FA52B1BEF0E007A076F /* ShareSheetView.swift in Sources */,
 				40F8C7FF2D1C800300C2948B /* View+border.swift in Sources */,
+				40F8C80F2D1CBF9300C2948B /* Double+digits.swift in Sources */,
 				40FDB38C2791FCFD0065FF47 /* FileAccess.swift in Sources */,
 				4068C3742B1A3A8D0033707F /* MultiPicker.swift in Sources */,
 				40A09C002B82D05700254501 /* UpdateManager+debugNotifications.swift in Sources */,
@@ -1062,11 +1095,14 @@
 				40E4430127877C5500FE245D /* GlobalConstants.swift in Sources */,
 				40A63B482B33265100996567 /* MainView.swift in Sources */,
 				40DF5F982B1BAFC5007A076F /* Window.swift in Sources */,
+				40F8C81A2D1CC74600C2948B /* AppTab.swift in Sources */,
+				40F8C81E2D1CCE8C00C2948B /* ToastView.swift in Sources */,
 				40A09C2F2B8439CC00254501 /* IndexUpdateStatus.swift in Sources */,
 				40A09BF12B8122F400254501 /* IndexUpdateError.swift in Sources */,
 				40E44348278A0A7100FE245D /* BestSeasonsViewModel.swift in Sources */,
 				40E4433727888D9100FE245D /* LocationService.swift in Sources */,
 				40B83C352B2F7CA500C843A7 /* CanyonAPIURL.swift in Sources */,
+				40F8C81C2D1CC86600C2948B /* MainTabViewModel.swift in Sources */,
 				40F17C692B9BFEE400BEBFF9 /* ManyCanyonMapView.swift in Sources */,
 				40DF5FA12B1BC500007A076F /* LargeProgressView.swift in Sources */,
 				40783CE9278DF46A001E78DB /* UserPreferencesStorage+favorite.swift in Sources */,
@@ -1085,6 +1121,7 @@
 				407FB7612790CD2B008B65BE /* NOAAData.swift in Sources */,
 				40A09BF82B8277C600254501 /* CanyonDataManager+write.swift in Sources */,
 				40E442D72787614000FE245D /* ColorPalette.swift in Sources */,
+				40F8C8202D1CCF2700C2948B /* ToastMessage.swift in Sources */,
 				40F17C892BB080BE00BEBFF9 /* MapboxMapViewModel+Polylines.swift in Sources */,
 				4068C35B2B179A9F0033707F /* StarQualityView.swift in Sources */,
 				405E6792279736C600BA41D9 /* DownloadBar.swift in Sources */,
@@ -1162,6 +1199,9 @@
 				401248BA2B26DC5B00E40553 /* CanyonTests.swift in Sources */,
 				40A09C132B82D8FF00254501 /* CanyonFilterViewModelTests+filter.swift in Sources */,
 				40A09C142B82D90000254501 /* DataTableViewModelTests.swift in Sources */,
+				40F8C8122D1CC08E00C2948B /* DoubleDigitsTests.swift in Sources */,
+				40F8C8152D1CC1C500C2948B /* PointIsCloseTests.swift in Sources */,
+				40F8C8182D1CC29300C2948B /* CLLocationCoordinate2DIsCloseTests.swift in Sources */,
 				40A09BFE2B82AA7C00254501 /* MockCanyonDataManager.swift in Sources */,
 				4089A1332B0AC9CF00886179 /* CoordinateTests.swift in Sources */,
 				40A63B4A2B3338A500996567 /* FavoriteServiceTests.swift in Sources */,

--- a/Canyoneer/Canyoneer/AppDataKit/Extensions/Double+digits.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Extensions/Double+digits.swift
@@ -1,0 +1,14 @@
+//  Created by Brice Pollock for Canyoneer on 12/25/24
+
+import Foundation
+
+extension Double {
+    func digits(_ numDigits: Int) -> Double {
+        guard numDigits > 0 else {
+            return self.rounded(.toNearestOrAwayFromZero)
+        }
+        
+        let precision = pow(Double(10), Double(numDigits))
+        return (self * precision).rounded(.toNearestOrAwayFromZero) / precision
+    }
+}

--- a/Canyoneer/Canyoneer/AppDataKit/Extensions/DoubleDigitsTests.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Extensions/DoubleDigitsTests.swift
@@ -1,0 +1,44 @@
+//  Created by Brice Pollock for Canyoneer on 2/18/24
+
+import Foundation
+import XCTest
+@testable import Canyoneer
+
+class DoubleDigitsTests: XCTestCase {
+    func testNoDigits_roundUp() {
+        let number: Double = 15.51
+        let expected: Double = 16
+        XCTAssertEqual(number.digits(0), expected)
+    }
+    
+    func testNoDigits_roundDown() {
+        let number: Double = 15.49
+        let expected: Double = 15
+        XCTAssertEqual(number.digits(0), expected)
+    }
+    
+    func testOneDigit_roundUp() {
+        let number: Double = 15.55
+        let expected: Double = 15.6
+        XCTAssertEqual(number.digits(1), expected)
+    }
+    
+    func testOneDigit_roundDown() {
+        let number: Double = 15.54
+        let expected: Double = 15.5
+        XCTAssertEqual(number.digits(1), expected)
+    }
+    
+    func testFourDigit_roundUp() {
+        let number: Double = 15.12345
+        let expected: Double = 15.1235
+        XCTAssertEqual(number.digits(4), expected)
+    }
+    
+    func testFourDigit_roundDown() {
+        let number: Double = 15.12344
+        let expected: Double = 15.1234
+        XCTAssertEqual(number.digits(4), expected)
+    }
+}
+   

--- a/Canyoneer/Canyoneer/AppDataKit/Models/CanyonDetailModels/Coordinate.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Models/CanyonDetailModels/Coordinate.swift
@@ -18,6 +18,10 @@ extension AnyCoordinate {
         return CLLocationCoordinate2D(latitude: self.latitude, longitude: self.longitude)
     }
     
+    var asString: String {
+        "\(self.latitude.digits(5)), \(self.longitude.digits(5))"
+    }
+    
     func distance(to coordinate: AnyCoordinate) -> Measurement<UnitLength> {
         let from = CLLocation(latitude: self.latitude, longitude: self.longitude)
         let to = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)

--- a/Canyoneer/Canyoneer/AppDataKit/Models/CanyonDetailModels/CoordinateTests.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Models/CanyonDetailModels/CoordinateTests.swift
@@ -10,6 +10,15 @@ import XCTest
 @testable import Canyoneer
 
 class CoordinateTests: XCTestCase {
+    func testString() {
+        let coordinate = Coordinate(
+            latitude: 36.3887494337,
+            longitude: -116.6066334955
+        )
+        let expected = "36.38875, -116.60663"
+        XCTAssertEqual(coordinate.asString, expected)
+    }
+    
     func testDistance() {
         let start = Coordinate(
             latitude: 36.3887494337,

--- a/Canyoneer/Canyoneer/AppTab.swift
+++ b/Canyoneer/Canyoneer/AppTab.swift
@@ -1,0 +1,45 @@
+//  Created by Brice Pollock for Canyoneer on 12/25/24
+
+import Foundation
+import SwiftUI
+
+enum AppTab: CaseIterable {
+    case map
+    case favorites
+    case search
+    
+    var index: Int {
+        switch self {
+        case .favorites: return 0
+        case .map: return 1
+        case .search: return 2
+        }
+    }
+    
+    var icon: UIImage {
+        switch self {
+        case .map: return UIImage(systemName: "map")!
+        case .favorites: return UIImage(systemName: "star")!
+        case .search: return UIImage(systemName: "magnifyingglass")!
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .map: return "Map"
+        case .favorites: return "Favorites"
+        case .search: return "Search"
+        }
+    }
+}
+
+struct CurrentTabKey: EnvironmentKey {
+    static var defaultValue: Binding<AppTab> = .constant(.favorites)
+}
+
+extension EnvironmentValues {
+    var currentTab: Binding<AppTab> {
+        get { self[CurrentTabKey.self] }
+        set { self[CurrentTabKey.self] = newValue }
+    }
+}

--- a/Canyoneer/Canyoneer/DesignSystem/Extensions/CLLocationCoordinate2D+isClose.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Extensions/CLLocationCoordinate2D+isClose.swift
@@ -4,12 +4,14 @@ import Foundation
 import CoreLocation
 
 extension CLLocationCoordinate2D {
+    /// - Parameter proximity: How close both latitude and longitude must be between points given the precision of this function (0.001)
     func isClose(to coordinate: CLLocationCoordinate2D, proximity: Double = 2) -> Bool {
-        let precision: Double = 1000
-        let selfCloseLat = (self.latitude * precision).rounded(.toNearestOrAwayFromZero)
-        let selfCloseLong = (self.longitude * precision).rounded(.toNearestOrAwayFromZero)
-        let pointCloseLat = (coordinate.latitude * precision).rounded(.toNearestOrAwayFromZero)
-        let pointCloseLong = (coordinate.longitude * precision).rounded(.toNearestOrAwayFromZero)
-        return abs(selfCloseLat - pointCloseLat) <= proximity && abs(selfCloseLong - pointCloseLong) <= proximity
+        let digits = 3
+        
+        // All this `.digits(digits+1)` stuff is because doing basic math is resulting in some error in 10^-14 range
+        let tolerance = (proximity / pow(Double(10), Double(digits))).digits(digits+1)
+        let latitudeDifference = abs(self.latitude - coordinate.latitude).digits(digits+1)
+        let longitudeDifference = abs(self.longitude - coordinate.longitude).digits(digits+1)
+        return latitudeDifference <= tolerance && longitudeDifference <= tolerance
     }
 }

--- a/Canyoneer/Canyoneer/DesignSystem/Extensions/CLLocationCoordinate2DIsCloseTests.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Extensions/CLLocationCoordinate2DIsCloseTests.swift
@@ -1,0 +1,46 @@
+//  Created by Brice Pollock for Canyoneer on 2/18/24
+
+import Foundation
+import XCTest
+import Turf
+import CoreLocation
+@testable import Canyoneer
+
+class CLLocationCoordinate2DIsCloseTests: XCTestCase {
+    func testIsClose_equal() {
+        let this = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        let that = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        XCTAssertTrue(this.isClose(to: that))
+    }
+    
+    func testIsClose_withinProximity() {
+        let this = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        let that = CLLocationCoordinate2D(latitude: 39.3230, longitude: -111.0917)
+        XCTAssertTrue(this.isClose(to: that))
+    }
+    
+    func testIsClose_outsideProximity_long() {
+        let this = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        let that = CLLocationCoordinate2D(latitude: 39.3230, longitude: -111.0907)
+        XCTAssertFalse(this.isClose(to: that))
+    }
+    
+    func testIsClose_outsideProximity_lat() {
+        let this = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        let that = CLLocationCoordinate2D(latitude: 39.3240, longitude: -111.0917)
+        XCTAssertFalse(this.isClose(to: that))
+    }
+    
+    func testIsClose_outsideProximity_both() {
+        let this = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        let that = CLLocationCoordinate2D(latitude: 39.3240, longitude: -111.0907)
+        XCTAssertFalse(this.isClose(to: that))
+    }
+    
+    func testIsClose_overrideProximity() {
+        let this = CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937)
+        let that = CLLocationCoordinate2D(latitude: 39.3240, longitude: -111.0907)
+        XCTAssertTrue(this.isClose(to: that, proximity: 3))
+    }
+}
+   

--- a/Canyoneer/Canyoneer/DesignSystem/Extensions/Point+isClose.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Extensions/Point+isClose.swift
@@ -5,11 +5,8 @@ import MapboxMaps
 
 extension Point {
     func isClose(to point: Point, proximity: Double = 2) -> Bool {
-        let precision: Double = 1000
-        let selfCloseLat = (self.coordinates.latitude * precision).rounded(.toNearestOrAwayFromZero)
-        let selfCloseLong = (self.coordinates.longitude * precision).rounded(.toNearestOrAwayFromZero)
-        let pointCloseLat = (point.coordinates.latitude * precision).rounded(.toNearestOrAwayFromZero)
-        let pointCloseLong = (point.coordinates.longitude * precision).rounded(.toNearestOrAwayFromZero)
-        return abs(selfCloseLat - pointCloseLat) <= proximity && abs(selfCloseLong - pointCloseLong) <= proximity
+        let this = self.coordinates.asCLObject
+        let that = point.coordinates.asCLObject
+        return this.isClose(to: that, proximity: proximity)
     }
 }

--- a/Canyoneer/Canyoneer/DesignSystem/Extensions/PointIsCloseTests.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Extensions/PointIsCloseTests.swift
@@ -1,0 +1,23 @@
+//  Created by Brice Pollock for Canyoneer on 2/18/24
+
+import Foundation
+import XCTest
+import Turf
+import CoreLocation
+@testable import Canyoneer
+
+class PointIsCloseTests: XCTestCase {
+    func testIsClose() {
+        let this = Point(CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937))
+        let that = Point(CLLocationCoordinate2D(latitude: 39.3230, longitude: -111.0917))
+        XCTAssertTrue(this.isClose(to: that))
+        XCTAssertTrue(this.isClose(to: that))
+    }
+    
+    func testIsClose_outsideProximity_both() {
+        let this = Point(CLLocationCoordinate2D(latitude: 39.3210, longitude: -111.0937))
+        let that = Point(CLLocationCoordinate2D(latitude: 39.3240, longitude: -111.0907))
+        XCTAssertFalse(this.isClose(to: that))
+    }
+}
+   

--- a/Canyoneer/Canyoneer/DesignSystem/Toast/ToastMessage.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Toast/ToastMessage.swift
@@ -1,0 +1,14 @@
+//  Created by Brice Pollock for Canyoneer on 12/25/24
+
+import SwiftUI
+
+struct ToastMessage: EnvironmentKey {
+    static var defaultValue: Binding<String?> = .constant(nil)
+}
+
+extension EnvironmentValues {
+    var toastMessage: Binding<String?> {
+        get { self[ToastMessage.self] }
+        set { self[ToastMessage.self] = newValue }
+    }
+}

--- a/Canyoneer/Canyoneer/DesignSystem/Toast/ToastView.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Toast/ToastView.swift
@@ -1,0 +1,40 @@
+//  Created by Brice Pollock for Canyoneer on 12/25/24
+
+import Foundation
+import SwiftUI
+
+struct ToastView: View {
+    @Environment(\.toastMessage) var toastMessage
+    
+    let message: String
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            Group {
+                Text(message)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(ColorPalette.GrayScale.white)
+                    .font(FontBook.Body.regular)
+                    .padding(8)
+            }
+            .background(ColorPalette.GrayScale.black.opacity(0.5))
+            .cornerRadius(8)
+            .onTapGesture {
+                toastMessage.wrappedValue = nil
+            }
+            .onAppear {
+                Task(priority: .userInitiated) { @MainActor in
+                    try? await Task.sleep(nanoseconds: Constants.duration * 1_000_000_000)
+                    toastMessage.wrappedValue = nil
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 52)
+    }
+    
+    enum Constants {
+        static let duration: UInt64 = 2
+    }
+}

--- a/Canyoneer/Canyoneer/MainTabViewModel.swift
+++ b/Canyoneer/Canyoneer/MainTabViewModel.swift
@@ -1,0 +1,51 @@
+//  Created by Brice Pollock for Canyoneer on 12/25/24
+
+import Foundation
+import SwiftUI
+
+@MainActor
+class MainTabViewModel: ObservableObject {
+    let tabs: [AppTab]
+    let mapViewModel: ManyCanyonMapViewModel
+    let favoriteViewModel: FavoriteListViewModel
+    let searchViewModel: SearchViewModel
+    
+    init(
+        allCanyons: [CanyonIndex],
+        canyonManager: CanyonDataManaging,
+        filterViewModel: CanyonFilterViewModel,
+        weatherViewModel: WeatherViewModel,
+        mapService: MapService,
+        favoriteService: FavoriteServing,
+        locationService: LocationService
+    ) {
+        self.tabs = AppTab.allCases.sorted { $0.index < $1.index }
+        
+        mapViewModel = ManyCanyonMapViewModel(
+            allCanyons: allCanyons,
+            applyFilters: true,
+            showOverlays: true,
+            filterViewModel: filterViewModel,
+            weatherViewModel: weatherViewModel,
+            canyonManager: canyonManager,
+            favoriteService: favoriteService
+        )
+        favoriteViewModel = FavoriteListViewModel(
+            weatherViewModel: weatherViewModel,
+            mapService: mapService,
+            canyonManager: canyonManager,
+            favoriteService: favoriteService,
+            locationService: locationService,
+            mapDelegate: mapViewModel
+        )
+        
+        searchViewModel = SearchViewModel(
+            searchService: SearchService(canyonManager: canyonManager),
+            filterViewModel: filterViewModel,
+            weatherViewModel: weatherViewModel,
+            canyonManager: canyonManager,
+            favoriteService: favoriteService,
+            locationService: locationService
+        )
+    }
+}

--- a/Canyoneer/Canyoneer/View/Canyon/CanyonDetailViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Canyon/CanyonDetailViewModel.swift
@@ -10,6 +10,7 @@ class CanyonDetailViewModel: NSObject, ObservableObject {
     @Published var webViewHeight: CGFloat = 200
     
     let canyonName: String
+    let canyonCoordinate: String
     let canyonSummary: String
     let ropeWikiURL: URL?
     let starViewModel: StarQualityViewModel
@@ -17,14 +18,21 @@ class CanyonDetailViewModel: NSObject, ObservableObject {
     let bestMonths: BestSeasonsViewModel
     let htmlString: String
     
+    /// If we have a `mapDelegate`, then we show the button to go this canyon on the main map
+    let showOnMapVisible: Bool
+    
     let weatherViewModel: WeatherForecastViewModel
     
     private let canyon: Canyon
+    private weak var mapDelegate: MainMapDelegate?
     
-    init(canyon: Canyon, weatherViewModel: WeatherViewModel) {
+    init(canyon: Canyon, weatherViewModel: WeatherViewModel, mapDelegate: MainMapDelegate?) {
         self.canyon = canyon
+        self.mapDelegate = mapDelegate
+        self.showOnMapVisible = mapDelegate != nil
         
         self.canyonName = canyon.name
+        self.canyonCoordinate = canyon.coordinate.asString
         self.canyonSummary = canyon.technicalSummary
         self.ropeWikiURL = canyon.ropeWikiURL
         self.starViewModel = StarQualityViewModel(quality: canyon.quality)
@@ -46,6 +54,11 @@ class CanyonDetailViewModel: NSObject, ObservableObject {
     public func launchRopeWikiURL() {
         guard let url = ropeWikiURL else { return }
         UIApplication.shared.open(url)
+    }
+    
+    @MainActor
+    public func showOnMap() {
+        mapDelegate?.updateCenter(to: canyon.coordinate.asCLObject, animated: false)
     }
     
     public func launchDirections() {

--- a/Canyoneer/Canyoneer/View/Canyon/CanyonDetailViewModelTests.swift
+++ b/Canyoneer/Canyoneer/View/Canyon/CanyonDetailViewModelTests.swift
@@ -10,6 +10,12 @@ import XCTest
 @testable import Canyoneer
 
 class CanyonDetailViewModelTests: XCTestCase {
+    
+    @MainActor
+    func testInit() {
+        let viewModel = CanyonDetailViewModel(canyon: Canyon(), weatherViewModel: WeatherViewModel(), mapDelegate: nil)
+        XCTAssertFalse(viewModel.showOnMapVisible)
+    }
    
     func testSummaryDetails_all() {
         let canyon = Canyon(risk: .x, maxRaps: 2)

--- a/Canyoneer/Canyoneer/View/Canyon/CanyonViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Canyon/CanyonViewModel.swift
@@ -27,6 +27,7 @@ class CanyonViewModel: NSObject, ObservableObject {
     private let favoriteService: FavoriteServing
     private let weatherViewModel: WeatherViewModel
     private let gpxService: GPXService
+    private weak var mapDelegate: MainMapDelegate?
     
     init(
         canyonId: String,
@@ -34,7 +35,8 @@ class CanyonViewModel: NSObject, ObservableObject {
         locationService: LocationService,
         favoriteService: FavoriteServing,
         weatherViewModel: WeatherViewModel,
-        gpxService: GPXService = GPXService()
+        gpxService: GPXService = GPXService(),
+        mapDelegate: MainMapDelegate?
     ) {
         self.canyonId = canyonId
         self.canyonManager = canyonManager
@@ -42,6 +44,7 @@ class CanyonViewModel: NSObject, ObservableObject {
         self.favoriteService = favoriteService
         self.weatherViewModel = weatherViewModel
         self.gpxService = gpxService
+        self.mapDelegate = mapDelegate
     }
     
     // MARK: Actions
@@ -54,7 +57,7 @@ class CanyonViewModel: NSObject, ObservableObject {
             
             isFavorite = self.favoriteService.isFavorite(canyon: canyon)
             
-            detailViewModel = CanyonDetailViewModel(canyon: canyon, weatherViewModel: weatherViewModel)
+            detailViewModel = CanyonDetailViewModel(canyon: canyon, weatherViewModel: weatherViewModel, mapDelegate: mapDelegate)
             self.singleCanyonViewModel = SingleCanyonMapViewModel(canyon: canyon)
         } catch {
             Global.logger.error(error)

--- a/Canyoneer/Canyoneer/View/Canyon/CanyonViewModelTests.swift
+++ b/Canyoneer/Canyoneer/View/Canyon/CanyonViewModelTests.swift
@@ -31,7 +31,8 @@ class CanyonViewModelTests: XCTestCase {
             canyonManager: manager,
             locationService: locationService,
             favoriteService: favorite,
-            weatherViewModel: WeatherViewModel()
+            weatherViewModel: WeatherViewModel(),
+            mapDelegate: nil
         )
     }
     

--- a/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModel.swift
@@ -21,13 +21,15 @@ class FavoriteListViewModel: ResultsViewModel {
     
     private var favorites: [Canyon] = []
     
+    /// - Parameter mapDelegate: The delegate we use to go to a favorite'd canyon on the main map in downstream UX (this is only allowed from Favorites)
     init(
         weatherViewModel: WeatherViewModel,
         mapService: MapService,
         canyonManager: CanyonDataManaging,
         favoriteService: FavoriteServing,
         locationService: LocationService,
-        updateManager: UpdateManager = UpdateManager.shared
+        updateManager: UpdateManager = UpdateManager.shared,
+        mapDelegate: MainMapDelegate
     ) {
         self.hasDownloadedAll = false
         self.progress = 0
@@ -45,7 +47,8 @@ class FavoriteListViewModel: ResultsViewModel {
             weatherViewModel: weatherViewModel,
             canyonManager: canyonManager,
             favoriteService: favoriteService,
-            locationService: locationService
+            locationService: locationService,
+            mapDelegate: mapDelegate
         )
         
         self.title = Strings.title

--- a/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModelTests.swift
+++ b/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModelTests.swift
@@ -8,6 +8,13 @@
 import Foundation
 import XCTest
 @testable import Canyoneer
+import CoreLocation
+
+class MockMapDelegate: MainMapDelegate {
+    public init() {}
+    
+    func updateCenter(to location: CLLocationCoordinate2D, animated: Bool) { }
+}
 
 @MainActor
 class FavoritesViewModelTests: XCTestCase {
@@ -26,7 +33,8 @@ class FavoritesViewModelTests: XCTestCase {
             mapService: MapService(),
             canyonManager: manager,
             favoriteService: favoriteService,
-            locationService: locationService
+            locationService: locationService,
+            mapDelegate: MockMapDelegate()
         )
     }
     

--- a/Canyoneer/Canyoneer/View/Map/BasicMap.swift
+++ b/Canyoneer/Canyoneer/View/Map/BasicMap.swift
@@ -14,8 +14,8 @@ protocol BasicMap {
     // MARK: Camera Methods
     
     /// Set the camera to the canyons
-    func focusCameraOn(canyon: Canyon, animate: Bool)
+    func focusCameraOn(canyon: Canyon, animated: Bool)
     
     /// Set the camera to current location
-    func focusCameraOn(location: CLLocationCoordinate2D, animate: Bool)
+    func focusCameraOn(location: CLLocationCoordinate2D, animated: Bool)
 }

--- a/Canyoneer/Canyoneer/View/Map/ManyCanyonMapView.swift
+++ b/Canyoneer/Canyoneer/View/Map/ManyCanyonMapView.swift
@@ -111,7 +111,8 @@ struct ManyCanyonMapView: View {
                             canyonManager: viewModel.canyonManager,
                             locationService: viewModel.locationService,
                             favoriteService: viewModel.favoriteService,
-                            weatherViewModel: viewModel.weatherViewModel
+                            weatherViewModel: viewModel.weatherViewModel,
+                            mapDelegate: nil
                         )
                     )
                 } else {

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel.swift
@@ -135,19 +135,19 @@ extension MapboxMapViewModel: BasicMap {
         }.store(in: &bag)
     }
     
-    func focusCameraOn(canyon: Canyon, animate: Bool) {
+    func focusCameraOn(canyon: Canyon, animated: Bool) {
         let center = canyon.coordinate.asCLObject
         let cameraDetails = CameraOptions(center: center, zoom: 11)
-        if animate {
+        if animated {
             self.mapView.camera.ease(to: cameraDetails, duration: 0.5)
         } else {
             self.mapView.mapboxMap.setCamera(to: cameraDetails)
         }
     }
     
-    func focusCameraOn(location: CLLocationCoordinate2D, animate: Bool) {
+    func focusCameraOn(location: CLLocationCoordinate2D, animated: Bool) {
         let cameraDetails = CameraOptions(center: location, zoom: 8)
-        if animate {
+        if animated {
             self.mapView.camera.ease(to: cameraDetails, duration: 0.5)
         } else {
             self.mapView.mapboxMap.setCamera(to: cameraDetails)

--- a/Canyoneer/Canyoneer/View/Map/MapListViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapListViewModel.swift
@@ -37,7 +37,8 @@ class MapListViewModel: ResultsViewModel {
             weatherViewModel: weatherViewModel,
             canyonManager: canyonManager,
             favoriteService: favoriteService,
-            locationService: locationService
+            locationService: locationService,
+            mapDelegate: nil
         )
         
         self.title = Strings.map(count: results.count)

--- a/Canyoneer/Canyoneer/View/Map/SingleCanyonMapViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Map/SingleCanyonMapViewModel.swift
@@ -32,7 +32,7 @@ class SingleCanyonMapViewModel: ObservableObject {
     
     public func onAppear() {
         self.mapViewModel.initialize()
-        self.mapViewModel.focusCameraOn(canyon: canyon, animate: false)
+        self.mapViewModel.focusCameraOn(canyon: canyon, animated: false)
         self.mapViewModel.updatePolylines(to: [canyon])
         self.mapViewModel.renderWaypoints(canyon: canyon)
         
@@ -51,6 +51,6 @@ class SingleCanyonMapViewModel: ObservableObject {
             return
         }
         self.lastUserLocation = currentLocation
-        self.mapViewModel.focusCameraOn(location: currentLocation, animate: true)
+        self.mapViewModel.focusCameraOn(location: currentLocation, animated: true)
     }
 }

--- a/Canyoneer/Canyoneer/View/NearMe/NearMeViewModel.swift
+++ b/Canyoneer/Canyoneer/View/NearMe/NearMeViewModel.swift
@@ -30,7 +30,8 @@ class NearMeViewModel: ResultsViewModel {
             weatherViewModel: weatherViewModel,
             canyonManager: canyonManager,
             favoriteService: favoriteService,
-            locationService: locationService
+            locationService: locationService,
+            mapDelegate: nil
         )
     }
     

--- a/Canyoneer/Canyoneer/View/ResultsBase/ResultListView.swift
+++ b/Canyoneer/Canyoneer/View/ResultsBase/ResultListView.swift
@@ -33,8 +33,8 @@ struct ResultListView: View {
                                 canyonManager: viewModel.canyonManager,
                                 locationService: viewModel.locationService,
                                 favoriteService: viewModel.favoriteService,
-                                weatherViewModel: viewModel.weatherViewModel
-
+                                weatherViewModel: viewModel.weatherViewModel,
+                                mapDelegate: viewModel.mapDelegate
                             )
                         )
                     } label: {

--- a/Canyoneer/Canyoneer/View/ResultsBase/ResultsViewModel.swift
+++ b/Canyoneer/Canyoneer/View/ResultsBase/ResultsViewModel.swift
@@ -31,7 +31,9 @@ import Combine
     public let weatherViewModel: WeatherViewModel
     public let filterSheetViewModel: CanyonFilterSheetViewModel
     public let filterViewModel: CanyonFilterViewModel
+    public private(set) weak var mapDelegate: MainMapDelegate?
 
+    /// - Parameter mapDelegate: Delegate for interacting with the map. If not nil then resulting `CanyonView`s will show a button to switch to map tab at the canyon's location
     init(
         applyFilters: Bool,
         filterViewModel: CanyonFilterViewModel,
@@ -39,7 +41,8 @@ import Combine
         weatherViewModel: WeatherViewModel,
         canyonManager: CanyonDataManaging,
         favoriteService: FavoriteServing,
-        locationService: LocationService
+        locationService: LocationService,
+        mapDelegate: MainMapDelegate?
     ) {
         self.title = ""
         self.unfilteredResults = []
@@ -50,6 +53,7 @@ import Combine
         self.canyonManager = canyonManager
         self.favoriteService = favoriteService
         self.locationService = locationService
+        self.mapDelegate = mapDelegate
         
         super.init()
         

--- a/Canyoneer/Canyoneer/View/Search/SearchViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Search/SearchViewModel.swift
@@ -43,7 +43,8 @@ class SearchViewModel: ResultsViewModel {
             weatherViewModel: weatherViewModel,
             canyonManager: canyonManager,
             favoriteService: favoriteService,
-            locationService: locationService
+            locationService: locationService,
+            mapDelegate: nil
         )
 
         self.title = Strings.search


### PR DESCRIPTION
### Description
Add button to move the map to a canyon from CanyonView page (only from favorites)
* Add coordinates section to view coordinate of canyon
* Add copy button next to coordinates that copies coordinates to pasteboard and presents toast to users

### Test Plan
* Tap into a canyon from map (no 'go to on map' button)
* See location section
* Tap copy button by coordinate
* "Copied" toast shows up
* Toast dismisses on its own
* Paste coordinates into another mapping app
* Return to Canyoneer
* Favorite this canyon
* Navigate map somewhere else
* Go to favorites
* Tap on that same map
* See "go to on map" button visible
* Tap "Go to on map" button
* App switches tap to "Map"
* Map now centered on that favorited canyon

(Important: make sure to test launching from favorite'd canyon before going to the map. It tests the map initialization race with updating coordinate)
