### PR TITLE
[ISSUE-38] Fixes issue with GPX line labels not showing up

### DIFF
--- a/Canyoneer/Canyoneer.xcodeproj/project.pbxproj
+++ b/Canyoneer/Canyoneer.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		4005DFBE278F5DD900EB1640 /* Logger+error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4005DFBD278F5DD900EB1640 /* Logger+error.swift */; };
 		4005DFC0278F60C500EB1640 /* CanyonFilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4005DFBF278F60C500EB1640 /* CanyonFilterViewModel.swift */; };
 		4005DFCD278F7B0A00EB1640 /* MockSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4005DFCC278F7B0A00EB1640 /* MockSearchService.swift */; };
+		40114E512D21D5FE00F6755F /* MapboxMapViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40114E4F2D21D5F700F6755F /* MapboxMapViewModelTests.swift */; };
+		40114E532D21E4A400F6755F /* Array+centerSort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40114E522D21E4A400F6755F /* Array+centerSort.swift */; };
+		40114E562D21E52500F6755F /* ArrayCenterSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40114E542D21E52500F6755F /* ArrayCenterSortTests.swift */; };
 		401248982B269AEC00E40553 /* index.json in Resources */ = {isa = PBXBuildFile; fileRef = 401248972B269AEB00E40553 /* index.json */; };
 		4012489A2B269B5700E40553 /* CanyonIndexData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401248992B269B5700E40553 /* CanyonIndexData.swift */; };
 		4012489C2B26A07C00E40553 /* RopeWikiCanyonIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4012489B2B26A07C00E40553 /* RopeWikiCanyonIndex.swift */; };
@@ -218,6 +221,9 @@
 		4005DFC6278F733400EB1640 /* CanyonFilterViewModelTests+filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanyonFilterViewModelTests+filter.swift"; sourceTree = "<group>"; };
 		4005DFCA278F7AAD00EB1640 /* NearMeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearMeViewModelTests.swift; sourceTree = "<group>"; };
 		4005DFCC278F7B0A00EB1640 /* MockSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchService.swift; sourceTree = "<group>"; };
+		40114E4F2D21D5F700F6755F /* MapboxMapViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxMapViewModelTests.swift; sourceTree = "<group>"; };
+		40114E522D21E4A400F6755F /* Array+centerSort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+centerSort.swift"; sourceTree = "<group>"; };
+		40114E542D21E52500F6755F /* ArrayCenterSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayCenterSortTests.swift; sourceTree = "<group>"; };
 		401248972B269AEB00E40553 /* index.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = index.json; sourceTree = "<group>"; };
 		401248992B269B5700E40553 /* CanyonIndexData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanyonIndexData.swift; sourceTree = "<group>"; };
 		4012489B2B26A07C00E40553 /* RopeWikiCanyonIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RopeWikiCanyonIndex.swift; sourceTree = "<group>"; };
@@ -839,6 +845,8 @@
 				40FDB38B2791FCFD0065FF47 /* FileAccess.swift */,
 				40F8C80E2D1CBF9300C2948B /* Double+digits.swift */,
 				40F8C8102D1CC07A00C2948B /* DoubleDigitsTests.swift */,
+				40114E522D21E4A400F6755F /* Array+centerSort.swift */,
+				40114E542D21E52500F6755F /* ArrayCenterSortTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -896,6 +904,7 @@
 				40F17C782BAF4D1900BEBFF9 /* MapboxMapViewModel+Visibility.swift */,
 				40F17C882BB080BE00BEBFF9 /* MapboxMapViewModel+Polylines.swift */,
 				40F17C902BB0C9C900BEBFF9 /* MapboxMapViewModel+CanyonPins.swift */,
+				40114E4F2D21D5F700F6755F /* MapboxMapViewModelTests.swift */,
 				40F17C802BAF502400BEBFF9 /* MapboxPolylineAnnotation+canyonLine.swift */,
 				40F17C9A2BB0E1C600BEBFF9 /* MapboxPolylineAnnotation+canyonLineTests.swift */,
 				40F17C7A2BAF4E1000BEBFF9 /* MapboxPointAnnotation+waypoint.swift */,
@@ -1069,6 +1078,7 @@
 				4005DFBE278F5DD900EB1640 /* Logger+error.swift in Sources */,
 				4005DFC0278F60C500EB1640 /* CanyonFilterViewModel.swift in Sources */,
 				40E443222787A0F200FE245D /* CanyonAPIService.swift in Sources */,
+				40114E532D21E4A400F6755F /* Array+centerSort.swift in Sources */,
 				407FB7632790CD2B008B65BE /* NOAASerializer.swift in Sources */,
 				40DF5FA52B1BEF0E007A076F /* ShareSheetView.swift in Sources */,
 				40F8C7FF2D1C800300C2948B /* View+border.swift in Sources */,
@@ -1181,6 +1191,7 @@
 				40A09C192B82D90000254501 /* CanyonViewModelTests.swift in Sources */,
 				40A09C102B82D8E100254501 /* NearMeViewModelTests.swift in Sources */,
 				40A09C152B82D90000254501 /* CanyonDetailViewModelTests.swift in Sources */,
+				40114E562D21E52500F6755F /* ArrayCenterSortTests.swift in Sources */,
 				40F17C992BB0E1BA00BEBFF9 /* MapboxPointAnnotation+canyonPinTests.swift in Sources */,
 				40A09C182B82D90000254501 /* StarQualityViewModelTests.swift in Sources */,
 				40A09C0F2B82D8DA00254501 /* FavoritesViewModelTests.swift in Sources */,
@@ -1209,6 +1220,7 @@
 				40F17C732BAF286C00BEBFF9 /* FilterStateTests.swift in Sources */,
 				40A09BF62B8275BB00254501 /* CanyonDataManagerTests.swift in Sources */,
 				40A09C1A2B82D90000254501 /* CanyonFilterViewModelTests+update.swift in Sources */,
+				40114E512D21D5FE00F6755F /* MapboxMapViewModelTests.swift in Sources */,
 				40A09C172B82D90000254501 /* WeatherDataPointTests+Strings.swift in Sources */,
 				40A09C042B82D74900254501 /* MockFavoriteService.swift in Sources */,
 			);

--- a/Canyoneer/Canyoneer/AppDataKit/Extensions/Array+centerSort.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Extensions/Array+centerSort.swift
@@ -1,0 +1,21 @@
+//  Created by Brice Pollock for Canyoneer on 12/29/24
+
+import Foundation
+
+extension Array {
+    func centerSort() -> [Element] {
+        if isEmpty {
+            return []
+        }
+        let middle = Int(self.count/2)
+        return enumerated()
+            .sorted { lhs, rhs in
+                let lhsDistance =  abs(lhs.offset - middle)
+                let rhsDistance =  abs(rhs.offset - middle)
+                return lhsDistance < rhsDistance
+            }
+            .map { idx, val in
+                val
+            }
+    }
+}

--- a/Canyoneer/Canyoneer/AppDataKit/Extensions/ArrayCenterSortTests.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Extensions/ArrayCenterSortTests.swift
@@ -1,0 +1,43 @@
+//  Created by Brice Pollock for Canyoneer on 2/18/24
+
+import Foundation
+import XCTest
+@testable import Canyoneer
+
+class ArrayCenterSortTests: XCTestCase {
+    func testCenterSort_empty() {
+        let array = [Int]()
+        XCTAssertEqual(array.centerSort(), array)
+    }
+    
+    func testCenterSort_single() {
+        let array = [5]
+        let expected = [5]
+        XCTAssertEqual(array.centerSort(), expected)
+    }
+    
+    func testCenterSort_two() {
+        let array = [4, 5]
+        let expected = [5, 4]
+        XCTAssertEqual(array.centerSort(), expected)
+    }
+    
+    func testCenterSort_three() {
+        let array = [4, 5, 6]
+        let expected = [5, 4, 6]
+        XCTAssertEqual(array.centerSort(), expected)
+    }
+    
+    func testCenterSort_many_even() {
+        let array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let expected = [6, 5, 7, 4, 8, 3, 9, 2, 10, 1]
+        XCTAssertEqual(array.centerSort(), expected)
+    }
+    
+    func testCenterSort_many_odd() {
+        let array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let expected = [5, 4, 6, 3, 7, 2, 8, 1, 9, 0, 10]
+        XCTAssertEqual(array.centerSort(), expected)
+    }
+}
+   

--- a/Canyoneer/Canyoneer/AppDataKit/Services/LocationService.swift
+++ b/Canyoneer/Canyoneer/AppDataKit/Services/LocationService.swift
@@ -13,6 +13,9 @@ class LocationService: NSObject, CLLocationManagerDelegate {
     @Published var heading: CLHeading?
     
     private var authorizationContinuation: CheckedContinuation<Bool, Never>?
+    
+    /// Need to be careful with resource contention of multiple callers creating parallel continuations
+    @MainActor
     private var currentLocationContinuation: CheckedContinuation<CLLocationCoordinate2D, Error>?
     
     private let locationManager = CLLocationManager()
@@ -21,6 +24,8 @@ class LocationService: NSObject, CLLocationManagerDelegate {
         return locationManager.authorizationStatus != .denied
     }
     
+    /// MainActor to prevent parallel continuations
+    @MainActor
     func getCurrentLocation() async throws -> CLLocationCoordinate2D {
         self.locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
         self.locationManager.delegate = self
@@ -44,23 +49,13 @@ class LocationService: NSObject, CLLocationManagerDelegate {
         self.locationManager.startUpdatingHeading()
                 
         // Clear out any pending task
-        currentLocationContinuation?.resume(throwing: GeneralError.canceled)
+        currentLocationContinuation?.resume(throwing: CancellationError())
         currentLocationContinuation = nil
         
         // Launch another
-        defer { currentLocationContinuation = nil }
         return try await withCheckedThrowingContinuation { continuation in
             currentLocationContinuation = continuation
             self.locationManager.requestLocation()
-        }
-        
-    }
-    
-    @objc func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let location = locations.last {
-            currentLocationContinuation?.resume(returning: location.coordinate)
-        } else {
-            currentLocationContinuation?.resume(throwing: GeneralError.notFound)
         }
     }
     
@@ -76,8 +71,32 @@ class LocationService: NSObject, CLLocationManagerDelegate {
         }
     }
     
+    // MARK: Location Updating
+    @objc func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        Task(priority: .high) {
+            await self.updateLocation(to: .success(locations.last))
+        }
+    }
+    
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        Global.logger.debug("error \(String(describing: error))");
-        currentLocationContinuation?.resume(throwing: GeneralError.unknownFailure)
+        Task(priority: .high) {
+            await self.updateLocation(to: .failure(error))
+        }
+    }
+    
+    @MainActor
+    private func updateLocation(to location: Result<CLLocation?, Error>) {
+        switch location {
+        case .success(let location):
+            if let location {
+                currentLocationContinuation?.resume(returning: location.coordinate)
+            } else {
+                currentLocationContinuation?.resume(throwing: GeneralError.notFound)
+            }
+        case .failure(let error):
+            Global.logger.debug("error getting location \(String(describing: error))");
+            currentLocationContinuation?.resume(throwing: GeneralError.unknownFailure)
+        }
+        currentLocationContinuation = nil
     }
 }

--- a/Canyoneer/Canyoneer/DesignSystem/Extensions/CLLocationCoordinate2D+isClose.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Extensions/CLLocationCoordinate2D+isClose.swift
@@ -4,14 +4,18 @@ import Foundation
 import CoreLocation
 
 extension CLLocationCoordinate2D {
+    /// - Parameter precision: What decimal place to look at for closeness
     /// - Parameter proximity: How close both latitude and longitude must be between points given the precision of this function (0.001)
-    func isClose(to coordinate: CLLocationCoordinate2D, proximity: Double = 2) -> Bool {
-        let digits = 3
-        
+    func isClose(to coordinate: CLLocationCoordinate2D, precision: Int = 3, proximity: Double = 2) -> Bool {
         // All this `.digits(digits+1)` stuff is because doing basic math is resulting in some error in 10^-14 range
-        let tolerance = (proximity / pow(Double(10), Double(digits))).digits(digits+1)
-        let latitudeDifference = abs(self.latitude - coordinate.latitude).digits(digits+1)
-        let longitudeDifference = abs(self.longitude - coordinate.longitude).digits(digits+1)
+        let tolerance = (proximity / pow(Double(10), Double(precision))).digits(precision+1)
+        let latitudeDifference = abs(self.latitude - coordinate.latitude).digits(precision+1)
+        let longitudeDifference = abs(self.longitude - coordinate.longitude).digits(precision+1)
+        
         return latitudeDifference <= tolerance && longitudeDifference <= tolerance
+    }
+    
+    func overlaps(coordinate: CLLocationCoordinate2D) -> Bool {
+        isClose(to: coordinate, precision: 4, proximity: 5)
     }
 }

--- a/Canyoneer/Canyoneer/DesignSystem/Extensions/PointIsCloseTests.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Extensions/PointIsCloseTests.swift
@@ -20,4 +20,3 @@ class PointIsCloseTests: XCTestCase {
         XCTAssertFalse(this.isClose(to: that))
     }
 }
-   

--- a/Canyoneer/Canyoneer/Foundation/GeneralError.swift
+++ b/Canyoneer/Canyoneer/Foundation/GeneralError.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum GeneralError: Error {
     case notFound
-    case canceled
     case permissionsDenied
     case unknownFailure
 }

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel+Waypoints.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel+Waypoints.swift
@@ -3,9 +3,10 @@
 import Foundation
 import CoreLocation
 import MapboxMaps
+import UIKit
 
 extension MapboxMapViewModel {    
-    func renderWaypoints(canyon: Canyon) {        
+    func renderWaypointsAndLineLabels(canyon: Canyon) {        
         // add waypoints from map
         var waypoints: [PointAnnotation] = []
         canyon.geoWaypoints.forEach { feature in
@@ -16,7 +17,7 @@ extension MapboxMapViewModel {
             let point = Point(first.asCLObject)
             
             // avoid any waypoints that overlap with others
-            if waypoints.contains(where: { $0.point.isClose(to: point, proximity: 1) }) == true {
+            if waypoints.contains(where: { $0.point.coordinates.overlaps(coordinate: point.coordinates) }) == true {
                 return
             }
             
@@ -32,24 +33,56 @@ extension MapboxMapViewModel {
         
         // add labels for the lines
         canyonLabelManager.annotations = canyon.geoLines.compactMap { feature -> PointAnnotation? in
-            // find a coordinate away from waypoints to label the polyline
-            var coordinates = feature.coordinates
-            var first: Coordinate? = coordinates.first
-            while let found = first {
-                let point = Point(found.asCLObject)
-                // if our line coordinate is far from other waypoints, then use it
-                if waypoints.contains(where: { $0.point.isClose(to: point) }) == false{
-                    break
-                }
-                coordinates = Array(coordinates.dropFirst())
-                first = coordinates.first
-            }
             // if couldn't find a coordinate away from waypoints then skip this label
-            guard let labelCoordinate = first else {
+            guard let labelCoordinate = unobstructedPoint(
+                on: feature.coordinates.map { $0.asCLObject },
+                given: waypoints.map { $0.point.coordinates }
+            ) else {
                 return nil
             }
             
-            return PointAnnotation.makeLabel(coordinate: labelCoordinate, topoName: feature.name)
+            return PointAnnotation.makeLabel(coordinate: labelCoordinate, topoName: feature.name, topoColor: feature.lineColor)
+        }
+    }
+    
+    /// Find an unobstructed location to put the label for the feature, iterating outward from the center
+    /// - Note: First tries to find a spaced out location for a clean map (better for longer lines) and then if it fails, just any point that doesn't overlap (best for shorter lines)
+    func unobstructedPoint(on line: [CLLocationCoordinate2D], given otherAnnotationCoordinates: [CLLocationCoordinate2D]) -> CLLocationCoordinate2D? {
+        guard line.isEmpty == false else {
+            return nil
+        }
+        
+        // Order from center out
+        let lineMiddleOrdered = line.centerSort()
+        
+        // Find the best coordinate closest to middle but a decent distance from the waypoints
+        // - Note: array-middle might not be similar to distance-middle
+        for currentLineCoordinate in lineMiddleOrdered {
+            if unobstructedPoint(point: currentLineCoordinate, by: otherAnnotationCoordinates, useOverlappingCriteria: false) {
+                return currentLineCoordinate
+            }
+        }
+        
+        // If couldn't find a coordinate that way, then use more forgiving criteria
+        for currentLineCoordinate in lineMiddleOrdered {
+            if unobstructedPoint(point: currentLineCoordinate, by: otherAnnotationCoordinates, useOverlappingCriteria: true) {
+                return currentLineCoordinate
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Whether the `point` is not obstructed by `otherCoordinates`
+    /// - Parameter useOverlappingCriteria: Whether to use the more forgiving `overlap` criteria for closenss to determine obstruction
+    func unobstructedPoint(point: CLLocationCoordinate2D, by otherCoordinates: [CLLocationCoordinate2D], useOverlappingCriteria: Bool) -> Bool {
+        return otherCoordinates.reduce(true) { acc, nextCoordinate in
+            if useOverlappingCriteria {
+                return acc && !nextCoordinate.overlaps(coordinate: point)
+            } else {
+                return acc && !nextCoordinate.isClose(to: point)
+            }
+            
         }
     }
 }

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel+Waypoints.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel+Waypoints.swift
@@ -41,7 +41,7 @@ extension MapboxMapViewModel {
                 return nil
             }
             
-            return PointAnnotation.makeLabel(coordinate: labelCoordinate, topoName: feature.name, topoColor: feature.lineColor)
+            return PointAnnotation.makeLabel(feature: feature, coordinate: labelCoordinate)
         }
     }
     

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModel.swift
@@ -104,6 +104,12 @@ extension MapboxMapViewModel: MapboxMapController {
         self.waypointManager.textIgnorePlacement = false
         self.waypointManager.iconIgnorePlacement = false
         self.waypointManager.textOptional = true
+        
+        // canyon line labels
+        self.canyonLabelManager.textAllowOverlap = false
+        self.canyonLabelManager.textIgnorePlacement = false
+        self.canyonLabelManager.iconIgnorePlacement = false
+        self.canyonLabelManager.iconOptional = true
     }
 }
 

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModelTests.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxMapViewModelTests.swift
@@ -1,0 +1,160 @@
+//  Created by Brice Pollock for Canyoneer on 2/18/24
+
+import Foundation
+import XCTest
+import CoreLocation
+
+@testable import Canyoneer
+
+class MapboxMapViewModelTests: XCTestCase {
+    func testWaypointLabelOverlap() throws {
+        // Test: Red Wall Canyon (West Fork) Topo lines show up
+        let viewModel = MapboxMapViewModel()
+        
+        let waypointCoordinates = [
+            CLLocationCoordinate2D(
+                latitude: 36.87538202852011,
+                longitude: -117.1882400102913
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.875041,
+                longitude: -117.182762
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87400563620031,
+                longitude: -117.1952138375491
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87308530323207,
+                longitude: -117.1817040536553
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.86921328306198,
+                longitude: -117.1957218647003
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.8342449888587,
+                longitude: -117.2225550189614
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87315110117197,
+                longitude: -117.1926189679653
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.86136245727539,
+                longitude: -117.209529876709
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.86393301934004,
+                longitude: -117.2102549951524
+            )
+        ]
+        
+        let northwestForkCoordinates = [
+            CLLocationCoordinate2D(
+                latitude: 36.87586532905698,
+                longitude: -117.1826720796526
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87572903931141,
+                longitude: -117.1826179325581
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.8755915760994,
+                longitude: -117.1826670505106
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87545428052545,
+                longitude: -117.1826989017427
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87531656585634,
+                longitude: -117.1827652025968
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87521916814148,
+                longitude: -117.1829009894282
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87508145347238,
+                longitude: -117.1829672902823
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.8749438226223,
+                longitude: -117.1830335911363
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87480627559125,
+                longitude: -117.1830826252699
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87465573661029,
+                longitude: -117.1830798592418
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87451919540763,
+                longitude: -117.1830429788679
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87443889677525,
+                longitude: -117.1828865725547
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87435859814286,
+                longitude: -117.1827302500606
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87422272749245,
+                longitude: -117.1826417371631
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87408618628979,
+                longitude: -117.1826047729701
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87396406196058,
+                longitude: -117.1825165115297
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.8738420214504,
+                longitude: -117.1824110671878
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87370556406677,
+                longitude: -117.1823741029948
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87356944195926,
+                longitude: -117.1823027729988
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87344748526812,
+                longitude: -117.1821973286569
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87331161461771,
+                longitude: -117.1821087319404
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87324497848749,
+                longitude: -117.1819526609033
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87317834235728,
+                longitude: -117.1817965898663
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87304222024977,
+                longitude: -117.1817252598703
+            ),
+            CLLocationCoordinate2D(
+                latitude: 36.87289184890688,
+                longitude: -117.1817053109407
+            )
+        ]
+        
+        let point = try XCTUnwrap(viewModel.unobstructedPoint(on: northwestForkCoordinates, given: waypointCoordinates))
+        XCTAssertEqual(point.latitude, 36.87435859814286)
+        XCTAssertEqual(point.longitude, -117.1827302500606)
+    }
+}

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPointAnnotation+topoLabel.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPointAnnotation+topoLabel.swift
@@ -3,11 +3,19 @@
 import Foundation
 import MapboxMaps
 import CoreLocation
+import UIKit
 
 extension PointAnnotation {
-    static func makeLabel(coordinate: AnyCoordinate, topoName: String?) -> PointAnnotation {
+    static func makeLabel(coordinate: AnyCoordinate, topoName: String?, topoColor: UIColor) -> PointAnnotation {
         var annotation = PointAnnotation(coordinate: coordinate.asCLObject)
         annotation.iconAnchor = .center
+        annotation.textField = topoName
+        annotation.textHaloBlur = 2
+        annotation.textHaloColor = StyleColor(topoColor)
+        annotation.textHaloWidth = 2
+        annotation.textOpacity = 100
+        annotation.textSize = 12
+        annotation.textColor = StyleColor(.white)
         return annotation
     }
 }

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPointAnnotation+topoLabel.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPointAnnotation+topoLabel.swift
@@ -5,17 +5,34 @@ import MapboxMaps
 import CoreLocation
 import UIKit
 
+extension CoordinateFeature {
+    /// The text color for the label of this line we show on map
+    var labelTextColor: UIColor {
+        return .white
+    }
+    
+    /// The background (halo) color for the label of this line we show on map
+    /// - Note: May be different than `lineColor` because of contrast between `labelTextColor`
+    var labelBackground: UIColor {
+        var finalColor = lineColor
+        while finalColor.contrastRatio(with: labelTextColor) < 1.5, let darker = finalColor.darker() {
+            finalColor = darker
+        }
+        return finalColor
+    }
+}
+
 extension PointAnnotation {
-    static func makeLabel(coordinate: AnyCoordinate, topoName: String?, topoColor: UIColor) -> PointAnnotation {
+    static func makeLabel(feature: CoordinateFeature, coordinate: AnyCoordinate) -> PointAnnotation {
         var annotation = PointAnnotation(coordinate: coordinate.asCLObject)
         annotation.iconAnchor = .center
-        annotation.textField = topoName
+        annotation.textField = feature.name
         annotation.textHaloBlur = 2
-        annotation.textHaloColor = StyleColor(topoColor)
+        annotation.textHaloColor = StyleColor(feature.labelBackground)
         annotation.textHaloWidth = 2
         annotation.textOpacity = 100
         annotation.textSize = 12
-        annotation.textColor = StyleColor(.white)
+        annotation.textColor = StyleColor(feature.labelTextColor)
         return annotation
     }
 }

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPolylineAnnotation+canyonLine.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPolylineAnnotation+canyonLine.swift
@@ -8,6 +8,7 @@ import UIKit
 fileprivate let topoBackgroundColor = UIColor(red: 158/255, green: 203/255, blue: 128/255, alpha: 1)
 
 extension CoordinateFeature {
+    /// The color for this line we show on map
     var lineColor: UIColor {
         let type = TopoLineType(string: name)
         let geoColor: UIColor?
@@ -17,14 +18,12 @@ extension CoordinateFeature {
             geoColor = nil
         }
         let lineColor = type == .unknown ? geoColor ?? UIColor(type.color) : UIColor(type.color)
-        let finalColor: UIColor
-        if lineColor.contrastRatio(with: topoBackgroundColor) < 1.5, let darker = lineColor.darker() {
+        var finalColor = lineColor
+        while finalColor.contrastRatio(with: topoBackgroundColor) < 1.5, let darker = finalColor.darker() {
             if type != .unknown {
                 assertionFailure("Our defined colors do not contrast nicely with background map green (see Imlay in Zion for an example)")
             }
             finalColor = darker
-        } else {
-            finalColor = lineColor
         }
         return finalColor
     }
@@ -33,7 +32,7 @@ extension CoordinateFeature {
 extension PolylineAnnotation {
     
     static func makeCanyonLineAnnotation(feature: CoordinateFeature, in canyon: CanyonIndex) -> PolylineAnnotation {
-        var annotation = PolylineAnnotation(id: Self.id(for: canyon), lineCoordinates: feature.coordinates.map { $0.asCLObject })        
+        var annotation = PolylineAnnotation(id: Self.id(for: canyon), lineCoordinates: feature.coordinates.map { $0.asCLObject })
         annotation.lineColor = StyleColor(feature.lineColor)
         annotation.lineWidth = 3
         annotation.lineOpacity = 0.5

--- a/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPolylineAnnotation+canyonLine.swift
+++ b/Canyoneer/Canyoneer/View/Map/MapBox/MapboxPolylineAnnotation+canyonLine.swift
@@ -5,13 +5,13 @@ import MapboxMaps
 import CoreLocation
 import UIKit
 
-extension PolylineAnnotation {
-    private static let topoBackgroundColor = UIColor(red: 158/255, green: 203/255, blue: 128/255, alpha: 1)
-    static func makeCanyonLineAnnotation(feature: CoordinateFeature, in canyon: CanyonIndex) -> PolylineAnnotation {
-        var annotation = PolylineAnnotation(id: Self.id(for: canyon), lineCoordinates: feature.coordinates.map { $0.asCLObject })
-        let type = TopoLineType(string: feature.name)
+fileprivate let topoBackgroundColor = UIColor(red: 158/255, green: 203/255, blue: 128/255, alpha: 1)
+
+extension CoordinateFeature {
+    var lineColor: UIColor {
+        let type = TopoLineType(string: name)
         let geoColor: UIColor?
-        if let stroke = feature.hexColor {
+        if let stroke = hexColor {
             geoColor = UIColor.hex(stroke)
         } else {
             geoColor = nil
@@ -26,7 +26,15 @@ extension PolylineAnnotation {
         } else {
             finalColor = lineColor
         }
-        annotation.lineColor = StyleColor(finalColor)
+        return finalColor
+    }
+}
+
+extension PolylineAnnotation {
+    
+    static func makeCanyonLineAnnotation(feature: CoordinateFeature, in canyon: CanyonIndex) -> PolylineAnnotation {
+        var annotation = PolylineAnnotation(id: Self.id(for: canyon), lineCoordinates: feature.coordinates.map { $0.asCLObject })        
+        annotation.lineColor = StyleColor(feature.lineColor)
         annotation.lineWidth = 3
         annotation.lineOpacity = 0.5
         return annotation

--- a/Canyoneer/Canyoneer/View/Map/SingleCanyonMapViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Map/SingleCanyonMapViewModel.swift
@@ -34,7 +34,7 @@ class SingleCanyonMapViewModel: ObservableObject {
         self.mapViewModel.initialize()
         self.mapViewModel.focusCameraOn(canyon: canyon, animated: false)
         self.mapViewModel.updatePolylines(to: [canyon])
-        self.mapViewModel.renderWaypoints(canyon: canyon)
+        self.mapViewModel.renderWaypointsAndLineLabels(canyon: canyon)
         
         // Observe the map state change to know whether centered on current location
         mapViewModel.$visibleMap


### PR DESCRIPTION
### Description
* Fixes crash with reused continuation races now that we request 'current location' more often
* Fixes rendering issue where we never really defined the rendering style for the line labels so they never showed up
* Do better positioning line labels to both be in relevant locations and prevent overlap with waypoints.
* Ensures contrasts for lines / text on map makes sense

### Image

<img width="559" alt="Screenshot 2024-12-29 at 1 00 11 PM" src="https://github.com/user-attachments/assets/030dfb6d-b796-4a37-9943-80fb820736cd" />

<img width="559" alt="Screenshot 2024-12-29 at 1 09 15 PM" src="https://github.com/user-attachments/assets/0f2d8fc0-f561-4360-b0d5-a6080052cb24" />


### Test Plan
* Ensure all line labels showing up on Red Wall Canyon (West Fork) which has some small lines sandwiched between waypoints and other lines
* Check out Behunin Canyon which has some custom line colorations that mess with rendering contrasts
