### PR TITLE
Fills in the filter button if filters are applied

### DIFF
--- a/Canyoneer/Canyoneer/View/Favorites/FavoriteListView.swift
+++ b/Canyoneer/Canyoneer/View/Favorites/FavoriteListView.swift
@@ -66,7 +66,7 @@ struct FavoriteListView: View {
                     }
                     .popoverTip(CanyoneerTips.downloadFavorites)
                     
-                    ImageButton(system: "line.3.horizontal.decrease.circle") {
+                    ImageButton(system: viewModel.anyFiltersActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle") {
                         showFilters = true
                     }
                     ImageButton(system: "map") {

--- a/Canyoneer/Canyoneer/View/Map/ManyCanyonMapView.swift
+++ b/Canyoneer/Canyoneer/View/Map/ManyCanyonMapView.swift
@@ -39,7 +39,7 @@ struct ManyCanyonMapView: View {
                             VStack(spacing: Grid.medium) {
                                 Spacer()
                                     .frame(height: 40)
-                                MapButton(system: "line.3.horizontal.decrease.circle") {
+                                MapButton(system: viewModel.anyFiltersActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle") {
                                     showFiltersSheet = true
                                 }
                                 .popoverTip(CanyoneerTips.mapFilter)

--- a/Canyoneer/Canyoneer/View/Map/ManyCanyonMapViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Map/ManyCanyonMapViewModel.swift
@@ -31,6 +31,9 @@ class ManyCanyonMapViewModel: ObservableObject, MainMapDelegate {
     @Published var canRenderTopoLines: Bool = false
     @Published var showCanyonDetails: Bool = false
     
+    /// Whether any filters are currently active on map
+    @Published var anyFiltersActive: Bool
+    
     /// Whether the map is centered at current location
     @Published var isAtCurrentLocation: Bool = false
     /// The user location the last time the 'go to current location' button was tapped
@@ -66,6 +69,7 @@ class ManyCanyonMapViewModel: ObservableObject, MainMapDelegate {
         self.allCanyons = allCanyons
         self.applyFilters = applyFilters
         self.showOverlays = showOverlays
+        self.anyFiltersActive = filterViewModel.areFiltersActive
         
         self.weatherViewModel = weatherViewModel
         self.canyonManager = canyonManager
@@ -98,6 +102,9 @@ class ManyCanyonMapViewModel: ObservableObject, MainMapDelegate {
         
         self.mapViewModel.initialize()
         self.updateInitialCamera()
+        
+        filterViewModel.$areFiltersActive
+            .assign(to: &$anyFiltersActive)
         
         self.$filteredCanyons
             .sink { canyons in

--- a/Canyoneer/Canyoneer/View/NearMe/NearMeView.swift
+++ b/Canyoneer/Canyoneer/View/NearMe/NearMeView.swift
@@ -25,7 +25,7 @@ struct NearMeView: View {
                 ImageButton(system: "map") {
                     showOnMap = true
                 }
-                ImageButton(system: "line.3.horizontal.decrease.circle") {
+                ImageButton(system: viewModel.anyFiltersActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle") {
                     showFilters = true
                 }
             }

--- a/Canyoneer/Canyoneer/View/ResultsBase/ResultsViewModel.swift
+++ b/Canyoneer/Canyoneer/View/ResultsBase/ResultsViewModel.swift
@@ -22,6 +22,9 @@ import Combine
     /// Keeps a copy of unfiltered results so we can apply different filter treatments to the same result-set
     @Published private var unfilteredResults: [QueryResult]
     
+    /// Whether any filters are currently active on map
+    @Published private(set) var anyFiltersActive: Bool
+    
     /// Whether view is processing query
     @Published var isLoading: Bool = false
     
@@ -47,6 +50,7 @@ import Combine
         self.title = ""
         self.unfilteredResults = []
         self.results = []
+        self.anyFiltersActive = filterViewModel.areFiltersActive
         self.filterViewModel = filterViewModel
         self.filterSheetViewModel = filterSheetViewModel
         self.weatherViewModel = weatherViewModel
@@ -56,6 +60,9 @@ import Combine
         self.mapDelegate = mapDelegate
         
         super.init()
+        
+        filterViewModel.$areFiltersActive
+            .assign(to: &$anyFiltersActive)
         
         $unfilteredResults.map { unfiltered in
             guard applyFilters else {

--- a/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 class CanyonFilterViewModel: ObservableObject {
     // Compiled
     @Published private(set) public var currentState: FilterState
+    @Published private(set) public var areFiltersActive: Bool
     
     // Filters
     @Published var maxRap: Bounds
@@ -32,6 +33,7 @@ class CanyonFilterViewModel: ObservableObject {
         self.shuttleRequired = initialState.shuttleRequired
         self.seasons = initialState.seasons
         self.currentState = initialState
+        self.areFiltersActive = initialState != .default
         
         self.$maxRap
             .combineLatest($numRaps, $stars, $technicality)
@@ -50,6 +52,12 @@ class CanyonFilterViewModel: ObservableObject {
                     seasons: seasons
                 )
             }.assign(to: &$currentState)
+        
+        self.$currentState
+            .map { state in
+                state != .default
+            }
+            .assign(to: &$areFiltersActive)
     }
     
     func reset() {

--- a/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModel.swift
@@ -39,6 +39,7 @@ class CanyonFilterViewModel: ObservableObject {
             .combineLatest($numRaps, $stars, $technicality)
             .combineLatest($water, $time, $shuttleRequired)
             .combineLatest($seasons)
+            .receive(on: DispatchQueue.main)
             .map { (combined, seasons) in
                 let (((maxRap), numRaps, stars, technicality), water, time, shuttleRequired) = combined
                 return FilterState(
@@ -54,6 +55,7 @@ class CanyonFilterViewModel: ObservableObject {
             }.assign(to: &$currentState)
         
         self.$currentState
+            .receive(on: DispatchQueue.main)
             .map { state in
                 state != .default
             }
@@ -81,6 +83,10 @@ class CanyonFilterViewModel: ObservableObject {
         
         if self.water != resetState.water {
             self.water = resetState.water
+        }
+        
+        if self.time != resetState.time {
+            self.time = resetState.time
         }
         
         if self.shuttleRequired != resetState.shuttleRequired {

--- a/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModelTests+update.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/CanyonFilterViewModelTests+update.swift
@@ -10,7 +10,31 @@ import XCTest
 @testable import Canyoneer
 
 @MainActor
-class CanyonFilterViewModelUpdateTests: XCTestCase {    
+class CanyonFilterViewModelUpdateTests: XCTestCase {
+    // MARK: isActive
+    
+    func testIsActive_init_default_update() {
+        let viewModel = CanyonFilterViewModel(initialState: .default)
+        XCTAssertFalse(viewModel.areFiltersActive)
+        
+        viewModel.time = [.three, .four]
+        XCTAssertTrue(viewModel.areFiltersActive)
+        
+        viewModel.reset()
+        XCTAssertFalse(viewModel.areFiltersActive)
+    }
+    
+    func testIsActive_init_reset() {
+        var state = FilterState(numRaps: Bounds(min: 3, max: 10))
+        let viewModel = CanyonFilterViewModel(initialState: state)
+        XCTAssertTrue(viewModel.areFiltersActive)
+        
+        viewModel.reset()
+        XCTAssertFalse(viewModel.areFiltersActive)
+    }
+    
+    // MARK: reset
+    
     func testStateReset() {
         // setup
         let viewModel = CanyonFilterViewModel(initialState: .default)

--- a/Canyoneer/Canyoneer/View/Shared/Filters/FilterState.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/FilterState.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-struct FilterState {
+struct FilterState: Equatable {
     /// Maximum rappel lengths, in feet
     let maxRap: Bounds
     let numRaps: Bounds

--- a/Canyoneer/Canyoneer/View/Shared/Filters/FilterStateTests.swift
+++ b/Canyoneer/Canyoneer/View/Shared/Filters/FilterStateTests.swift
@@ -21,7 +21,60 @@ class FilterStateTests: XCTestCase {
         XCTAssertEqual(state.time.count, 6)
         XCTAssertNil(state.shuttleRequired)
         XCTAssertEqual(state.seasons.count, 12)
-
+    }
+    
+    func testEqual_default() {
+        let testState = FilterState()
+        let defaultState = FilterState.default
+        XCTAssertEqual(testState, defaultState)
+    }
+    
+    func testEqual_maxRap() {
+        let testState = FilterState(maxRap: Bounds(min: 0, max: 100))
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_numRaps() {
+        let testState = FilterState(numRaps: Bounds(min: 0, max: 100))
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_stars() {
+        let testState = FilterState(stars: [2,3])
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_technicality() {
+        let testState = FilterState(technicality: [.four])
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_water() {
+        let testState = FilterState(water: [.c1])
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_time() {
+        let testState = FilterState(time: [.one])
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_shuttle() {
+        let testState = FilterState(shuttleRequired: false)
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
+    }
+    
+    func testEqual_seasons() {
+        let testState = FilterState(seasons: [.june])
+        let defaultState = FilterState.default
+        XCTAssertNotEqual(testState, defaultState)
     }
 }
 


### PR DESCRIPTION
### Description
Fills in filter button on Favorites, Nearby, main Map areas to indicate whether filters are in an active state. This will help prevent it being unclear if filters are applied.

<img width="559" alt="Screenshot 2024-12-29 at 1 53 03 PM" src="https://github.com/user-attachments/assets/1ceb07ee-6846-423b-a61f-7f4f72d69f71" />

<img width="559" alt="Screenshot 2024-12-29 at 1 53 14 PM" src="https://github.com/user-attachments/assets/388bd347-4a7f-431b-b079-303a6cccd6b7" />

<img width="559" alt="Screenshot 2024-12-29 at 1 53 26 PM" src="https://github.com/user-attachments/assets/da31b88f-f033-4fba-8d99-5d9a670df16d" />


### Test Plan
* Apply filters and reset them with reset button and by going back to default state on each view
* See filter fills tate change
