### PR TITLE
Apply the same filter everywhere and avoid 'missing' favorites by having a section for unmatched

### DIFF
--- a/Canyoneer/Canyoneer/DesignSystem/Foundation/ColorPalette.swift
+++ b/Canyoneer/Canyoneer/DesignSystem/Foundation/ColorPalette.swift
@@ -14,6 +14,7 @@ enum ColorPalette {
         static let dark = SwiftUI.Color(uiColor: .darkGray)
         static let gray = SwiftUI.Color.gray
         static let light = SwiftUI.Color(UIColor(white: 0.9, alpha: 1))
+        static let extraLight = SwiftUI.Color(UIColor(white: 0.95, alpha: 1))
         static let white = SwiftUI.Color.white
     }
     

--- a/Canyoneer/Canyoneer/MainTabViewModel.swift
+++ b/Canyoneer/Canyoneer/MainTabViewModel.swift
@@ -34,6 +34,7 @@ class MainTabViewModel: ObservableObject {
             weatherViewModel: weatherViewModel,
             mapService: mapService,
             canyonManager: canyonManager,
+            filterViewModel: filterViewModel,
             favoriteService: favoriteService,
             locationService: locationService,
             mapDelegate: mapViewModel

--- a/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModel.swift
+++ b/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModel.swift
@@ -26,6 +26,7 @@ class FavoriteListViewModel: ResultsViewModel {
         weatherViewModel: WeatherViewModel,
         mapService: MapService,
         canyonManager: CanyonDataManaging,
+        filterViewModel: CanyonFilterViewModel,
         favoriteService: FavoriteServing,
         locationService: LocationService,
         updateManager: UpdateManager = UpdateManager.shared,
@@ -36,9 +37,6 @@ class FavoriteListViewModel: ResultsViewModel {
 
         self.mapService = mapService
         self.profileViewModel = ProfileViewModel(updateManager: updateManager)
-        
-        // Favorites has its own filter disconnected from map
-        let filterViewModel = CanyonFilterViewModel(initialState: .default)
         
         super.init(
             applyFilters: true,

--- a/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModelTests.swift
+++ b/Canyoneer/Canyoneer/View/Favorites/FavoritesViewModelTests.swift
@@ -32,6 +32,7 @@ class FavoritesViewModelTests: XCTestCase {
             weatherViewModel: WeatherViewModel(),
             mapService: MapService(),
             canyonManager: manager,
+            filterViewModel: CanyonFilterViewModel(initialState: .default),
             favoriteService: favoriteService,
             locationService: locationService,
             mapDelegate: MockMapDelegate()

--- a/Canyoneer/Canyoneer/View/ResultsBase/CanyonItemView.swift
+++ b/Canyoneer/Canyoneer/View/ResultsBase/CanyonItemView.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 struct CanyonItemView: View {
     @State var result: QueryResult
+    let isDisabled: Bool
     
     var body: some View {
         HStack(alignment: .center, spacing: .medium) {
             Text(result.name)
+                .font(FontBook.Body.regular)
+                .foregroundStyle(isDisabled ? ColorPalette.GrayScale.gray : ColorPalette.GrayScale.black)
                 .lineLimit(nil)
                 .multilineTextAlignment(.leading)
                 // make the text fill all remaining space in stack
@@ -21,16 +24,21 @@ struct CanyonItemView: View {
             VStack(alignment: .center , spacing: .small) {
                 StarQualityView(viewModel: StarQualityViewModel(quality: result.canyonDetails.quality))
                 Text(result.canyonDetails.technicalSummary)
+                    .font(FontBook.Body.regular)
+                    .foregroundStyle(isDisabled ? ColorPalette.GrayScale.gray : ColorPalette.GrayScale.black)
             }
         }
         .padding(.horizontal, .medium)
-        .background(ColorPalette.GrayScale.white)
+        .padding(.vertical, .medium)
+        .background(isDisabled ? ColorPalette.GrayScale.extraLight : ColorPalette.GrayScale.white)
     }
 }
 
 struct CanyonItemView_Previews: PreviewProvider {
     static var previews: some View {
         let result = QueryResult(name: "Moonflower Canyon with a long name", canyonDetails: CanyonIndex(data: RopeWikiCanyonIndex()))
-        CanyonItemView(result: result)
+        CanyonItemView(result: result, isDisabled: false)
+        
+        CanyonItemView(result: result, isDisabled: true)
     }
 }

--- a/Canyoneer/Canyoneer/View/ResultsBase/ResultListView.swift
+++ b/Canyoneer/Canyoneer/View/ResultsBase/ResultListView.swift
@@ -21,11 +21,8 @@ struct ResultListView: View {
     
     var body: some View {
         ScrollView {
-            VStack(spacing: Grid.medium) {
+            VStack(spacing: .zero) {
                 ForEach(viewModel.results) { result in
-                    if result.id != viewModel.results.first?.id {
-                        Divider()
-                    }
                     NavigationLink {
                         CanyonView(
                             viewModel: CanyonViewModel(
@@ -38,8 +35,32 @@ struct ResultListView: View {
                             )
                         )
                     } label: {
-                        CanyonItemView(result: result)
+                        CanyonItemView(result: result, isDisabled: false)
                     }.buttonStyle(.plain)
+                    
+                    Divider()
+                }
+                
+                if !viewModel.hiddenResults.isEmpty {
+                    HStack {
+                        Text(Strings.hidden)
+                            .font(FontBook.Body.emphasis)
+                            .foregroundStyle(ColorPalette.GrayScale.dark)
+                            .underline()
+                            .padding(.top, Grid.medium)
+                        
+                        Spacer()
+                    }
+                    .padding(.horizontal, .medium)
+                    .padding(.bottom, .medium)
+                    .background(ColorPalette.GrayScale.extraLight)
+                    
+                    Divider()
+                    
+                    ForEach(viewModel.hiddenResults) { result in
+                        CanyonItemView(result: result, isDisabled: true)
+                        Divider()
+                    }
                 }
             }
         }.overlay {
@@ -51,4 +72,8 @@ struct ResultListView: View {
         }
         .navigationTitle(viewModel.title)
     }
+         
+     private enum Strings {
+         static let hidden = "Favorites that don't match filters"
+     }
 }


### PR DESCRIPTION
### Description
Have the same filters applied app-wide instead of different filter settings on "Favorites" and Map + Search

Addresses the 'why aren't I seeing some of my favorites' problem by having a 'unmatched' section of those canyons after those that match you preferences.

<img width="559" alt="Screenshot 2024-12-29 at 2 30 38 PM" src="https://github.com/user-attachments/assets/0f3d1a85-91ce-44b5-ae0a-2d9d30dd4506" />


### Test Plan
* Apply filters and see them across all pages
* No filters on favorites
* Filters that exclude multiple rows
